### PR TITLE
feat: update support android ios with shared preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ A Flutter plugin for displaying cookie consent banners and managing cookie prefe
 | Platform | Support |
 |----------|---------|
 | Web      | ✅      |
-| Android  | ❌      |
-| iOS      | ❌      |
+| Android  | ✅      |
+| iOS      | ✅      |
 | Windows  | ❌      |
 | macOS    | ❌      |
 | Linux    | ❌      |
@@ -52,7 +52,70 @@ flutter pub get
 
 ## Usage
 
+### Example Project
+Here's a simple example showing how to use the `createBanner` method to display a cookie consent banner:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_cookie_consent/flutter_cookie_consent.dart';
+
+class MyApp extends StatefulWidget {
+  const MyApp({super.key});
+
+  @override
+  State<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  final FlutterCookieConsent _cookieConsent = FlutterCookieConsent();
+  late final Future<void> _initFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _initFuture = _cookieConsent.initialize();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: FutureBuilder(
+          future: _initFuture,
+          builder: (context, snapshot) {
+            if (snapshot.connectionState == ConnectionState.waiting) {
+              return const Center(child: CircularProgressIndicator());
+            }
+
+            return Stack(
+              children: [
+                // Your app content
+                const Center(
+                  child: Text('Welcome to our app!'),
+                ),
+                // Cookie consent banner
+                _cookieConsent.createBanner(
+                  context: context,
+                  title: 'Cookie Settings',
+                  message: 'We use cookies to enhance your browsing experience...',
+                  acceptButtonText: 'Accept',
+                  declineButtonText: 'Decline',
+                  settingsButtonText: 'Settings',
+                  showSettings: true,
+                  position: BannerPosition.top,
+                ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
 ### Basic Usage
+
+The following is a minimal implementation that you can use with the example code above:
 
 ```dart
 import 'package:flutter_cookie_consent/flutter_cookie_consent.dart';
@@ -79,9 +142,10 @@ class MyApp extends StatelessWidget {
     );
   }
 }
-```
 
 ### Advanced Usage
+
+You can also customize the banner with more options. Here's an example that you can integrate with the main example code:
 
 ```dart
 CookieConsentBanner(
@@ -135,6 +199,8 @@ CookieConsentBanner(
 
 ### Checking Consent Status
 
+You can check the consent status in your app like this:
+
 ```dart
 final cookieConsent = FlutterCookieConsent();
 
@@ -149,6 +215,8 @@ if (cookieConsent.shouldShowBanner) {
   // Show banner
 }
 ```
+
+These examples can be integrated with the main example code to create a complete cookie consent solution for your app.
 
 ## API Reference
 
@@ -175,4 +243,13 @@ The main class for managing cookie consent.
 ### BannerPosition
 
 Enum for specifying banner position:
-- `
+- `BannerPosition.top`: Display banner at the top of the screen
+- `BannerPosition.bottom`: Display banner at the bottom of the screen
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/lib/flutter_cookie_consent_platform_interface.dart
+++ b/lib/flutter_cookie_consent_platform_interface.dart
@@ -1,6 +1,8 @@
+import 'package:flutter/foundation.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 import 'flutter_cookie_consent_method_channel.dart';
+import 'flutter_cookie_consent_web.dart';
 
 /// Platform interface for cookie consent functionality.
 ///
@@ -12,12 +14,19 @@ abstract class FlutterCookieConsentPlatform extends PlatformInterface {
 
   static final Object _token = Object();
 
-  static FlutterCookieConsentPlatform _instance =
-      MethodChannelFlutterCookieConsent();
+  static FlutterCookieConsentPlatform _instance = _getPlatformImplementation();
+
+  static FlutterCookieConsentPlatform _getPlatformImplementation() {
+    if (kIsWeb) {
+      return FlutterCookieConsentWeb();
+    }
+    return MethodChannelFlutterCookieConsent();
+  }
 
   /// The default instance of [FlutterCookieConsentPlatform] to use.
   ///
-  /// Defaults to [MethodChannelFlutterCookieConsent].
+  /// Defaults to [MethodChannelFlutterCookieConsent] for mobile platforms
+  /// and [FlutterCookieConsentWeb] for web platform.
   static FlutterCookieConsentPlatform get instance => _instance;
 
   /// Platform-specific implementations should set this with their own

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
     sdk: flutter
   web: ^0.5.1
   plugin_platform_interface: ^2.0.2
+  shared_preferences: ^2.5.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
# Flutter Cookie Consent 1.0.1 버전 업데이트

## 변경사항

### 추가된 기능
- 모바일 플랫폼(Android/iOS)에서 shared_preferences 지원 추가
- 쿠키 설정 저장 구현 개선

### 변경된 내용
- README의 플랫폼 지원 정보 업데이트
- 문서 및 예제 개선

### 수정된 문제
- 모바일 플랫폼에서 쿠키 설정 지속성 문제 해결
- 플랫폼별 저장소 구현 수정

## 주요 변경점 설명

1. **저장소 구현 개선**
   - 모바일 플랫폼에서 shared_preferences를 사용하여 쿠키 설정을 영구적으로 저장
   - Web 플랫폼은 기존 localStorage 사용 유지

2. **플랫폼 지원 명확화**
   - Web, Android, iOS 플랫폼 지원
   - 데스크톱 플랫폼(Windows, macOS, Linux) 지원 제외

3. **문서 개선**
   - README.md에 실제 예제 코드 추가
   - 플랫폼별 사용법 명확화

## 테스트 방법
1. Web 플랫폼에서 쿠키 설정 저장/불러오기 테스트
2. Android/iOS 플랫폼에서 shared_preferences를 통한 설정 저장/불러오기 테스트
3. 플랫폼 간 설정 동기화 테스트
