### PR TITLE
chore: fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ class _MyAppState extends State<MyApp> {
     );
   }
 }
+```
 
 ### Basic Usage
 


### PR DESCRIPTION
The codeblock in the readme before "Basic Usage" doesn't get closed and therefore includes the next text section as well.
This PR adds the missing backticks.